### PR TITLE
fix(security): upgrade simple-git  to address RCE vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "commander": "^8.0.0",
         "figlet": "^1.5.0",
         "ora": "^5.4.0",
-        "simple-git": "^2.0.0"
+        "simple-git": "^3.27.0"
       },
       "bin": {
         "ntw": "cli.js"
@@ -408,18 +408,18 @@
       "license": "ISC"
     },
     "node_modules/simple-git": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.48.0.tgz",
-      "integrity": "sha512-z4qtrRuaAFJS4PUd0g+xy7aN4y+RvEt/QTJpR184lhJguBA1S/LsVlvE/CM95RsYMOFJG3NGGDjqFCzKU19S/A==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.27.0.tgz",
+      "integrity": "sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==",
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.2"
+        "debug": "^4.3.5"
       },
       "funding": {
         "type": "github",
-        "url": "https://github.com/sponsors/steveukx/"
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "commander": "^8.0.0",
-    "simple-git": "^2.0.0",
+    "simple-git": "^3.27.0",
     "chalk": "^4.0.0",
     "figlet": "^1.5.0",
     "ora": "^5.4.0"


### PR DESCRIPTION
Patched a critical Remote Code Execution (RCE) vulnerability in `simple-git` by upgrading to version superior to 3.16.0. 

The vulnerability (CVE-2022-25860) affects versions prior to 3.16.0 and allows RCE via improper input sanitization in the `clone()`, `pull()`, `push()`, and `listRemote()` methods. This issue is tracked under GitHub Security Advisory (GHSA-9w5j-4mwv-2wj8) and has a CVSS score of 9.8.

Details: https://github.com/advisories/GHSA-9w5j-4mwv-2wj8

Related GitHub fix: #1.

More info: https://github.com/advisories/GHSA-9w5j-4mwv-2wj8